### PR TITLE
Fix Mobile hamburger menu

### DIFF
--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -54,17 +54,39 @@ export default function MobileMenu() {
   return (
     <div className="flex md:hidden">
       <button
-        ref={trigger}
-        className={`hamburger ml-5 ${mobileNavOpen && 'active'}`}
+	ref={trigger}
+        className="hamburger ml-5"
         aria-controls="mobile-nav"
-        aria-expanded={mobileNavOpen}
+        aria-expanded={mobileNavOpen ? "true" : "false"}
         onClick={() => setMobileNavOpen(!mobileNavOpen)}
       >
         <span className="sr-only">Menu</span>
-        <svg className="w-6 h-6 fill-current text-gray-100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <rect y="4" width="24" height="2" />
-          <rect y="11" width="24" height="2" />
-          <rect y="18" width="24" height="2" />
+        <svg
+          className={`w-6 h-6 fill-current text-gray-100 transform transition-transform duration-300 ${
+            mobileNavOpen ? "rotate-90" : ""
+          }`}
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          {mobileNavOpen ? (
+            // Close button
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+            >
+              <line x1="6" y1="6" x2="18" y2="18" />
+              <line x1="6" y1="18" x2="18" y2="6" />
+            </g>
+          ) : (
+            //three lines
+            <>
+              <rect y="4" width="24" height="2" fill="currentColor" />
+              <rect y="11" width="24" height="2" fill="currentColor" />
+              <rect y="18" width="24" height="2" fill="currentColor" />
+            </>
+          )}
         </svg>
       </button>
 


### PR DESCRIPTION
## Summary:  Fixes hamburger menu close button in mobile devices

The close button SVG icon is now centered, well defined and in bounds.
This is done by adding a if-condition for `mobileNavOpen` in `components/ui/mobile-menu.tsx` such that it displays the X-icon SVG when it is true form `aria-expanded` attribute

`Fixes #188 `:  https://github.com/pbdsce/PB_Website/issues/188



## Changes Made
- [x] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Configuration changes
- [ ] Other (please specify)

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)

Please describe the test cases and expected behavior:
1. The svg icon must be in bounds and not clipped
2. Added case for if the menu is opened

## Screenshots

![dev-fix](https://github.com/user-attachments/assets/1196c41e-06c4-4028-8798-b9a397541d01)

## Dependencies

No

## Documentation
- [ ] I have updated the documentation accordingly
- [x] Documentation update is not required

## Comments:

None

## Reviewer Notes

<!--Any specific areas you'd like reviewers to focus on?
-->
