### PR TITLE
Feat-otp: add otp verification to emails

### DIFF
--- a/components/forms/pbctfForm/ParticipantForm.tsx
+++ b/components/forms/pbctfForm/ParticipantForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { UseFormRegister, FieldErrors, UseFormWatch } from 'react-hook-form';
 import { FormData } from './types';
 
@@ -7,16 +7,160 @@ interface ParticipantFormProps {
   register: UseFormRegister<FormData>;
   errors: FieldErrors<FormData>;
   watch: UseFormWatch<FormData>;
+  onEmailVerificationChange?: (isVerified: boolean) => void;
 }
 
 const ParticipantForm: React.FC<ParticipantFormProps> = ({ 
   participantNumber, 
   register, 
   errors, 
-  watch 
+  watch,
+  onEmailVerificationChange 
 }) => {
   const watchPreviousCTF = watch(`participant${participantNumber}.previousCTF`);
+  const watchEmail = watch(`participant${participantNumber}.email`);
   
+  // Separate loading states
+  const [isSendingOTP, setIsSendingOTP] = useState(false);
+  const [isVerifyingOTP, setIsVerifyingOTP] = useState(false);
+  
+  // OTP states
+  const [otpSent, setOtpSent] = useState(false);
+  const [otpVerified, setOtpVerified] = useState(false);
+  const [otp, setOtp] = useState('');
+  const [canResend, setCanResend] = useState(false);
+  const [resendTimer, setResendTimer] = useState(0);
+  
+  // Message states
+  const [otpError, setOtpError] = useState('');
+  const [otpSuccess, setOtpSuccess] = useState('');
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (resendTimer > 0) {
+      interval = setInterval(() => {
+        setResendTimer(prev => prev - 1);
+      }, 1000);
+    } else if (resendTimer === 0 && otpSent) {
+      setCanResend(true);
+    }
+    
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [resendTimer, otpSent]);
+
+  useEffect(() => {
+    if (watchEmail && (otpSent || otpVerified)) {
+      resetOTPState();
+    }
+  }, [watchEmail]);
+
+  useEffect(() => {
+    if (onEmailVerificationChange) {
+      onEmailVerificationChange(otpVerified);
+    }
+  }, [otpVerified, onEmailVerificationChange]);
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const resetOTPState = () => {
+    setOtpSent(false);
+    setOtpVerified(false);
+    setOtp('');
+    setCanResend(false);
+    setResendTimer(0);
+    setOtpError('');
+    setOtpSuccess('');
+  };
+  const validateEmail = (email: string): boolean => {
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    return emailRegex.test(email);
+  };
+  const sendOTP = async () => {
+    if (!watchEmail) {
+      setOtpError('Please enter a valid email address first');
+      return;
+    }
+    if (!validateEmail(watchEmail)) {
+      setOtpError('Please enter a valid email address');
+      return;
+    }
+    setIsSendingOTP(true);
+    setOtpError('');
+    setOtpSuccess('');
+    try {
+      const response = await fetch('/api/registration/pbctf/?action=sendOTP', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: watchEmail,
+          registrationData: {} 
+        }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setOtpSent(true);
+        setOtpSuccess('OTP sent successfully to your email');
+        setResendTimer(120); 
+        setCanResend(false);
+      } else {
+        setOtpError(data.error || 'Failed to send OTP');
+      }
+    } catch (error) {
+      setOtpError('Network error. Please try again.');
+      console.error('Error sending OTP:', error);
+    } finally {
+      setIsSendingOTP(false);
+    }
+  };
+  const verifyOTP = async () => {
+    if (!otp || otp.length !== 6) {
+      setOtpError('Please enter a valid 6-digit OTP');
+      return;
+    }
+    setIsVerifyingOTP(true);
+    setOtpError('');
+    setOtpSuccess('');
+    try {
+      const response = await fetch('/api/registration/pbctf/?action=verifyOTP', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: watchEmail,
+          otp: otp,
+        }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setOtpVerified(true);
+        setOtpSuccess('Email verified successfully!');
+        setOtpError('');
+      } else {
+        setOtpError(data.error || 'Invalid OTP');
+      }
+    } catch (error) {
+      setOtpError('Network error. Please try again.');
+      console.error('Error verifying OTP:', error);
+    } finally {
+      setIsVerifyingOTP(false);
+    }
+  };
+
+  const handleOTPChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/\D/g, '').slice(0, 6);
+    setOtp(value);
+    setOtpError('');
+  };
+
   return (
     <div className="space-y-6">
       {/* Basic Info Section */}
@@ -42,24 +186,95 @@ const ParticipantForm: React.FC<ParticipantFormProps> = ({
             )}
           </div>
 
-          <div>
-            <input
-              {...register(`participant${participantNumber}.email` as const, {
-                required: "Email is required",
-                pattern: {
-                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-                  message: "Invalid email address",
-                },
-              })}
-              placeholder="Email Address"
-              type="email"
-              className="w-full bg-gray-900/50 border border-green-400/30 rounded px-4 py-3 text-green-300 font-mono text-sm focus:border-green-400 focus:outline-none transition-colors placeholder-gray-500"
-            />
-            {errors[`participant${participantNumber}`]?.email && (
-              <p className="mt-1 text-xs text-red-400 font-mono">
-                {errors[`participant${participantNumber}`]?.email?.message}
-              </p>
-            )}
+          <div className="md:col-span-2">
+            <div className="space-y-3">
+              <div className="flex md:flex-row flex-col gap-2">
+                <input
+                  {...register(`participant${participantNumber}.email` as const, {
+                    required: "Email is required",
+                    pattern: {
+                      value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                      message: "Invalid email address",
+                    },
+                  })}
+                  placeholder="Email Address"
+                  type="email"
+                  disabled={otpVerified}
+                  className={`flex-1 bg-gray-900/50 border border-green-400/30 rounded px-4 py-3 text-green-300 font-mono text-sm focus:border-green-400 focus:outline-none transition-colors placeholder-gray-500 ${
+                    otpVerified ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                />
+                {!otpVerified && (
+                  <button
+                    type="button"
+                    onClick={sendOTP}
+                    disabled={isSendingOTP || !watchEmail}
+                    className="px-4 py-3 bg-green-600 text-white font-mono text-sm rounded hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors min-w-[100px]"
+                  >
+                    {isSendingOTP ? 'Sending...' : otpSent ? 'Resend OTP' : 'Send OTP'}
+                  </button>
+                )}
+                {otpVerified && (
+                  <div className="flex items-center px-3 py-2 bg-green-600/20 border border-green-400/30 rounded">
+                    <span className="text-green-300 font-mono text-sm">✓ Verified</span>
+                  </div>
+                )}
+              </div>
+
+              {otpSent && !otpVerified && (
+                <div className="flex md:flex-row flex-col gap-2">
+                  <input
+                    type="text"
+                    value={otp}
+                    onChange={handleOTPChange}
+                    placeholder="Enter 6-digit OTP"
+                    maxLength={6}
+                    className="flex-1 bg-gray-900/50 border border-green-400/30 rounded px-4 py-3 text-green-300 font-mono text-sm focus:border-green-400 focus:outline-none transition-colors placeholder-gray-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={verifyOTP}
+                    disabled={isVerifyingOTP || otp.length !== 6}
+                    className="px-4 py-3 bg-green-600 text-white font-mono text-sm rounded hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors min-w-[100px]"
+                  >
+                    {isVerifyingOTP ? 'Verifying...' : 'Verify'}
+                  </button>
+                </div>
+              )}
+
+              {otpSent && !otpVerified && (
+                <div className="flex justify-between items-center">
+                  <button
+                    type="button"
+                    onClick={sendOTP}
+                    disabled={!canResend || isSendingOTP}
+                    className="text-green-400 font-mono text-sm hover:text-green-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {canResend ? '' : `Resend in ${formatTime(resendTimer)}`}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resetOTPState}
+                    className="text-gray-400 font-mono text-sm hover:text-gray-300 transition-colors"
+                  >
+                    Change Email
+                  </button>
+                </div>
+              )}
+
+              {otpError && (
+                <p className="text-xs text-red-400 font-mono">{otpError}</p>
+              )}
+              {otpSuccess && (
+                <p className="text-xs text-green-400 font-mono">{otpSuccess}</p>
+              )}
+              
+              {errors[`participant${participantNumber}`]?.email && (
+                <p className="text-xs text-red-400 font-mono">
+                  {errors[`participant${participantNumber}`]?.email?.message}
+                </p>
+              )}
+            </div>
           </div>
 
           <div>
@@ -124,7 +339,13 @@ const ParticipantForm: React.FC<ParticipantFormProps> = ({
           </div>
         </div>
       </div>
-
+      {!otpVerified && watchEmail && (
+        <div className="bg-yellow-600/20 border border-yellow-400/30 rounded-lg p-3">
+          <p className="text-yellow-300 font-mono text-sm">
+            ⚠️ Please verify your email address before proceeding
+          </p>
+        </div>
+      )}
       {/* Participant Background Section */}
       <div className="bg-gray-800/30 border border-green-400/20 rounded-lg p-4">
         <h4 className="text-green-300 font-mono text-sm mb-4 flex items-center gap-2">

--- a/models/CTFRegs.ts
+++ b/models/CTFRegs.ts
@@ -18,14 +18,19 @@ interface Background {
   howDidYouHearAboutUs?: string[];
 }
 
-
-
+interface TempCTFUser {
+  email: string;
+  otp: string;
+  otpExpiresAt: Date;
+}
 
 export interface Registration extends Document {
   participant1: Participant;
   participant2?: Participant;
   participationType: "solo" | "duo";
 }
+
+export interface TempCTFUserDoc extends Document, TempCTFUser {}
 
 const backgroundSchema = new Schema({
   experienceLevel: {
@@ -66,7 +71,6 @@ const registrationSchema = new Schema<Registration>({
       return this.participationType === "duo";
     },
   },
-
   participationType: {
     type: String,
     enum: ["solo", "duo"],
@@ -74,8 +78,21 @@ const registrationSchema = new Schema<Registration>({
   },
 });
 
+const tempCTFUserSchema = new Schema<TempCTFUserDoc>({
+  email: { type: String, required: true, unique: true },
+  otp: { type: String, required: true },
+  otpExpiresAt: { type: Date, required: true },
+});
+
+tempCTFUserSchema.index({ otpExpiresAt: 1 }, { expireAfterSeconds: 0 });
+
 const CtfRegsModel =
   mongoose.models.ctfregs ||
   mongoose.model<Registration>("ctfregs", registrationSchema);
 
+const TempCTFUserModel =
+  mongoose.models.tempctfusers ||
+  mongoose.model<TempCTFUserDoc>("tempctfusers", tempCTFUserSchema);
+
 export default CtfRegsModel;
+export { TempCTFUserModel };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "next": "^15.0.3",
         "next-swagger-doc": "^0.4.1",
         "next-themes": "^0.3.0",
+        "nodemailer": "^7.0.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.53.0",
@@ -51,6 +52,7 @@
         "@tailwindcss/forms": "^0.5.7",
         "@types/aos": "^3.0.7",
         "@types/lodash": "^4.17.16",
+        "@types/nodemailer": "^6.4.17",
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.13",
         "tailwindcss": "^3.3.6"
@@ -2109,6 +2111,16 @@
       "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -6567,6 +6579,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next": "^15.0.3",
     "next-swagger-doc": "^0.4.1",
     "next-themes": "^0.3.0",
+    "nodemailer": "^7.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.53.0",
@@ -52,6 +53,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@types/aos": "^3.0.7",
     "@types/lodash": "^4.17.16",
+    "@types/nodemailer": "^6.4.17",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.13",
     "tailwindcss": "^3.3.6"


### PR DESCRIPTION
## Summary:  What does this PR do?

Sends OTP to users' email and verifies it before proceeding to the submit form.

## Which issue(s) this PR fixes:
Fixes #352 

## Changes Made
Describe the changes you've made in this PR:
- [x] Feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Configuration changes
- [ ] Other (please specify)

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How Has This Been Tested?
Describe the tests you ran:
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)

Please describe the test cases and expected behavior:
1. Filled the form for solo and duo users. Adding their emails and sent otp.
2. Sending, verifying and resending the otp after interval has been tested

## Screenshots (if applicable)

https://github.com/user-attachments/assets/b50c877f-ed92-47ea-82bd-1d39fa0ca465

<img width="378" height="666" alt="image" src="https://github.com/user-attachments/assets/1570a8f4-1d75-473a-8d22-77bf1f5866cf" />


## Dependencies

- Nodemailer

## Documentation
- [ ] I have updated the documentation accordingly
- [x] Documentation update is not required

## Comments:
- 2 new envs needs to be added

## Reviewer Notes

- the db is checked for connection everytime while sendotp request is sent in order to check for existing mails and also to handle cold db start. No major issues with it though
- The otp checking is done before the form is submitted btw.
