### PR TITLE
Removes PBCTF announcements from landing page

### DIFF
--- a/app/(default)/pbctf/page.tsx
+++ b/app/(default)/pbctf/page.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 const PBCTFRegisterPage = () => {
   return (
     <div className="min-h-screen mt-10 bg-black text-green-400 font-mono overflow-hidden">
+      {/*PBCTF content commented out for future use
       <div className="hidden" id="secret-agent-flag" data-flag="pbctf{pls_h4ck_m3_d4ddy}">
         🕵️‍♂️ CTF SECRET AGENT FLAG: pbctf&#123;pls_h4ck_m3_d4ddy&#125; 🕵️‍♂️
       </div>
@@ -93,6 +94,7 @@ const PBCTFRegisterPage = () => {
           backgroundSize: '20px 20px'
         }} />
       </div>
+      */}
     </div>
   );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,10 +39,7 @@ export default function RootLayout({
         className={`${inter.variable} font-inter antialiased bg-black text-white tracking-tight`}
       >
         <NextThemesProvider>
-          <Link href="/pbctf" className="flex w-full bg-yellow-500 text-black p-2 justify-center items-center text-center z-50 fixed top-0 left-0">
-            🚨 PBCTF Registration is LIVE! 🚨
-          </Link>
-          <div className="flex flex-col min-h-screen overflow-hidden supports-[overflow:clip]:overflow-clip pt-10">
+          <div className="flex flex-col min-h-screen overflow-hidden supports-[overflow:clip]:overflow-clip">
             <Header />
             {children}
           </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -32,7 +32,7 @@ export default function Hero() {
                       <span className="bg-[#00c853] p-2 sm:p-3 rounded-xl" style={{ wordBreak: 'keep-all' }}>tech-community</span> from Dayananda Sagar College of Engineering.
                     </p>
                   </div>
-                  <PBCTFbanner/>
+                  {/* <PBCTFbanner/> */}
                 </div>
               </div>
             </div>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -14,7 +14,6 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 const navItems = [
   { href: "https://github.com/pbdsce", label: "GitHub", isExternal: true, icon: faGithub},
-  { href: "/pbctf", label: "PBCTF" },
   { href: "/events", label: "Events" },
   { href: "/leads", label: "Leads" },
   { href: "/lore", label: "Lore" },

--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -12,7 +12,6 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 const mobileNavItems = [
   { href: "https://github.com/pbdsce", label: "GitHub", isExternal: true, icon: faGithub },
-  { href: "/pbctf", label:"PBCTF"},
   { href: "/events", label: "Events" },
   { href: "/leads", label: "Leads" },
   { href: "/lore", label: "Lore" },


### PR DESCRIPTION
this PR removes CTF banner , PBCTF from navbar and hides the code for future use
<img width="1919" height="1037" alt="Screenshot 2025-08-04 120328" src="https://github.com/user-attachments/assets/751eea59-6d1e-4117-9855-67432f8d2d10" />
(in events page the PBCTF4.0 card has been already moved to past events)