### PR TITLE
Recruitment option made visible in navbar in mobile view

### DIFF
--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -12,6 +12,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 const mobileNavItems = [
   { href: "https://github.com/pbdsce", label: "GitHub", isExternal: true, icon: faGithub },
+  { href: "/recruitment", label: "Recruitment" },
   { href: "/events", label: "Events" },
   { href: "/leads", label: "Leads" },
   { href: "/lore", label: "Lore" },


### PR DESCRIPTION
initially the recruitment forms option was not visible in navbar in mobile view which this pr fixes 