### PR TITLE
Disabled recruitment banner

### DIFF
--- a/app/(default)/recruitment/page.tsx
+++ b/app/(default)/recruitment/page.tsx
@@ -32,9 +32,9 @@ const RegisterPage = () => {
             className="mt-9"
           />
         </Link> */}
-        <div className="form-container my-2">
+        {/* <div className="form-container my-2">
           <RecruitmentForm />
-        </div>
+        </div> */}
       </div>
     </>
   );

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -34,7 +34,7 @@ export default function Hero() {
                     </p>
                   </div>
                   <div className="flex flex-col items-center gap-3 p-1 transform scale-90 sm:scale-75 hero-banners">
-                  <RecruitmentBanner />
+                  {/* <RecruitmentBanner /> */}
                   {/*<SIHbanner />*/}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary:  What does this PR do?
Removed recruitment banner from homepage
Commented out recruitment page

<img width="1919" height="881" alt="Screenshot 2025-12-15 011611" src="https://github.com/user-attachments/assets/e32f4414-b781-4268-a849-062c17bff5fa" />
