### PR TITLE
Add alumni page and remove alumni from members

### DIFF
--- a/app/(default)/alumni/page.tsx
+++ b/app/(default)/alumni/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Card from "@/components/ui/Card";
+import LoadingBrackets from "@/components/ui/loading-brackets";
+
+interface Member {
+  id?: string;
+  name: string;
+  role: string;
+  company?: string;
+  year: string;
+  linkedInUrl?: string;
+  imageUrl?: string;
+}
+
+export default function AlumniPage() {
+  const [alumni, setAlumni] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAlumni = async () => {
+      try {
+        const res = await fetch("/api/membersData");
+        const data: Member[] = await res.json();
+
+        const alumniOnly = data
+          .filter((member) => member.year === "Alumni")
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        setAlumni(alumniOnly);
+      } catch (error) {
+        console.error("Error fetching alumni:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAlumni();
+  }, []);
+
+  return (
+    <main className="flex flex-col items-center mt-24 bg-black min-h-screen">
+      <h1 className="text-4xl font-bold text-white mb-10">Alumni</h1>
+
+      {loading ? (
+        <LoadingBrackets />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-16">
+          {alumni.map((profile) => (
+            <Card
+              key={profile.id}
+              name={profile.name}
+              role={profile.role}
+              company={profile.company || ""}
+              linkedInUrl={profile.linkedInUrl || ""}
+              imageUrl={profile.imageUrl || ""}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <main style={{ padding: "2rem" }}>
+      <h1>About</h1>
+      <p>This is the About page.</p>
+    </main>
+  );
+}

--- a/components/Members.tsx
+++ b/components/Members.tsx
@@ -20,7 +20,6 @@ interface Member {
 }
 
 const headings = [
-  "Alumni",
   "Fourth Year",
   "Third Year",
   "Second Year",

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -17,6 +17,7 @@ const navItems = [
   { href: "/leads", label: "Leads" },
   { href: "/lore", label: "Lore" },
   { href: "/members", label: "Members", specialPadding: true },
+  { href: "/alumni", label: "Alumni"},
   { href: "/achievements", label: "Achievements" },
   { href: "/hustle", label: "Hustle Results" },
 ];

--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -15,6 +15,7 @@ const mobileNavItems = [
   { href: "/leads", label: "Leads" },
   { href: "/lore", label: "Lore" },
   { href: "/members", label: "Members" },
+  { href: "/alumni", label: "Alumni"},
   { href: "/achievements", label: "Achievements" },
   { href: "/hustle", label: "Hustle Results" }
 ];


### PR DESCRIPTION
### What this PR does
- Created a separate Alumni page
- Removed Alumni section from Members page
- Added Alumni link to navbar (desktop & mobile)
- Alumni list is sorted alphabetically
<img width="1892" height="921" alt="Screenshot 2025-12-25 013330" src="https://github.com/user-attachments/assets/bb3f6faf-2d42-4671-931d-e2181a5ea161" />
<img width="1914" height="918" alt="Screenshot 2025-12-25 013353" src="https://github.com/user-attachments/assets/61c7ad9a-6b3e-4be9-beb8-cae01d99861c" />


