### PR TITLE
FIX: Lore UI for Mobile Screens

### DIFF
--- a/components/lore/lore-card.tsx
+++ b/components/lore/lore-card.tsx
@@ -62,14 +62,14 @@ export default function LoreCard({
         className="cursor-pointer"
         onClick={onCardClick}
       >
-      <div className="flex flex-col md:flex-row gap-6 p-8">
-        <div className="bg-black rounded-2xl shadow-lg overflow-hidden p-4 max-w-2xl mx-auto" onClick={(e)=> e.stopPropagation()}>
+      <div className="flex flex-col md:flex-row gap-6 p-4 sm:p-8">
+        <div className="bg-black rounded-2xl shadow-lg overflow-hidden p-4 max-w-2xl h-fit mx-auto" onClick={(e)=> e.stopPropagation()}>
 
         <EmblaCarousel slides={Lore.images} options={{ loop: true }}/>
       </div>
 
           <div className="md:w-2/3">
-            <h2 className="text-5xl font-bold mb-4 text-[#00c853] group">
+            <h2 className="text-4xl xsm:text-5xl font-bold mb-4 text-[#00c853] group">
               <span className="relative inline-block">
                 {Lore.title}
               </span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -197,6 +197,7 @@ module.exports = {
         },
       },
       screens: {
+        "xsm":"420px",//Custom breakpoint for small screens 
         "2gl": "750px", // Custom breakpoint for 2 columns
         "3gl": "1070px", // Custom breakpoint for 3 cloumns
         "landscape": { "raw": "(orientation: landscape)" }, // Landscape orientation breakpoint


### PR DESCRIPTION
## Summary:  What does this PR do?

FIXES LORE UI BUGS FOR MOBILE SCREENS


-Changed Padding according to breakpoints for Lore Container
-Added Text breakpoints to Lore Container Title
-Fixed Height overflow of Image Container on Tablet/Ipad Screens
(IMAGES ATTACHED BELOW)
## Which issue(s) this PR fixes:

[PB-57](https://linear.app/point-blank/issue/PB-57/lore-title-overflow-on-mobile-screens)


## Changes Made
Describe the changes you've made in this PR:
- [ ] Feature implementation
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Configuration changes
- [ ] Other (please specify)

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How Has This Been Tested?
Describe the tests you ran:
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)


## Screenshots (if applicable)

1.
Before :
<img width="357" height="768" alt="image" src="https://github.com/user-attachments/assets/5eb334bd-b41f-47d2-9cb2-8ce8f4f7574e" />

After:
<img width="357" height="768" alt="image" src="https://github.com/user-attachments/assets/c8866ddb-922c-4471-9969-9367fc174deb" />

2.
Before:
<img width="569" height="514" alt="image" src="https://github.com/user-attachments/assets/811251b6-8058-4058-a9f8-8c70668ff76c" />

After:
<img width="558" height="513" alt="image" src="https://github.com/user-attachments/assets/f62fa9f7-8ebe-4a31-a346-b47df7323555" />


## Documentation
- [ ] I have updated the documentation accordingly
- [x] Documentation update is not required



